### PR TITLE
Rack 1.3.0 update and other cleanups

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,9 @@ Ruby and Ruby frameworks.</p>
 <h2>News</h2>
 
 <dl>
+<dt>May 23rd, 2011<dt>
+<dd><strong>Rack 1.3.0</strong> has been <a href="http://groups.google.com/group/rack-devel/browse_thread/thread/7dce0d9b17ec9cb3">released</a>!</dd>
+
 <dt>June 13th, 2010</dt><dd>
 <strong>Rack 1.2.0</strong> has been <a href="http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/364270">released</a>!</dd>
 
@@ -132,19 +135,19 @@ Ruby and Ruby frameworks.</p>
 
 <dt>December 24th, 2008</dt><dd><a href="http://groups.google.com/group/rack-devel/browse_thread/thread/a5f156a8c592ab1c">Introducing the Rack Core Team</a></dd>
 
-<dt>December 23rd, 2008</dt><dd><a href="http://www.heise.de/newsticker/Rails-Erfinder-stellt-Rails-Metal-vor--/meldung/120849">Rack is mentioned on <a href="http://www.heise.de/newsticker/Rails-Erfinder-stellt-Rails-Metal-vor--/meldung/120849">heise.de</a>!</a></dd>
+<dt>December 23rd, 2008</dt><dd><a href="http://www.heise.de/newsticker/Rails-Erfinder-stellt-Rails-Metal-vor--/meldung/120849">Rack is mentioned on heise.de</a>!</dd>
 
 <dt>December 5th, 2008</dt><dd><a href="http://weblog.rubyonrails.org/2008/12/5/this-week-in-edge-rails">The tighter integration of Rails with Rack continues.</a></dd>
 
 <dt>August 21st, 2008</dt><dd><strong>Rack 0.4</strong> has been <a href="http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/312148">released</a>!</dd>
 
-<dt>May 31st, 2008</dt><dd>Rack development <a href="http://github.com/chneukirchen/rack/tree/master">moves to Git</a>.</dd>
+<dt>May 31st, 2008</dt><dd>Rack development <a href="https://github.com/rack/rack">moves to Git</a>.</dd>
 
 <dt>May 24th, 2008</dt><dd>There now is a Google Group on <a href="http://groups.google.com/group/rack-devel">Rack Development</a>.</dd>
 
 <dt>February 26th, 2008</dt><dd><strong>Rack 0.3</strong> has been <a href="http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/292557">released</a>!</dd>
 
-<dt>November 10th, 2007</dt><dd>Rack has been presented at the <a href="http://euruko.com/">Euruko 2007</a>.  Slides and a paper are available at <a href="http://chneukirchen.org/talks/#introducingrack">http://chneukirchen.org/talks/</a>.</dd>
+<dt>November 10th, 2007</dt><dd>Rack has been presented at the Euruko 2007.</dd>
 
 <dt>October 2007</dt><dd>Ryan Allen gave a <a href="http://yeahnah.org/files/rack-presentation-oct-07.pdf">presentation on Rack</a> (PDF).</dd>
 
@@ -180,6 +183,8 @@ month. It makes our life good!
   Releases:
 </p>
 <dl>
+  <dt>Rack 1.3.0</dt>
+  <dd><a href="http://chneukirchen.org/releases/rack-1.3.0.tar.gz">rack-1.3.0.tar.gz</a> (<tt>214a3af03896e9b1fbddbe647b796426d930edd8</tt>)</dd>
   <dt>Rack 1.2.0</dt>
   <dd><a href="http://chneukirchen.org/releases/rack-1.2.0.tar.gz">rack-1.2.0.tar.gz</a> (<tt>c69b0a120b249832f9701e6a9fe6692e6728940f</tt>)</dd>
   <dd><a href="http://rubyforge.org/frs/download.php/71197/rack-1.2.0.tar.gz">rack-1.2.0.tar.gz (Rubyforge)</a></dd>
@@ -217,9 +222,6 @@ month. It makes our life good!
 </p>
 <pre><code>gem install rack
 </code></pre>
-  Mirror, may be more recent:
-<pre><code>gem install rack --source http://chneukirchen.org/releases/gems/
-</code></pre>
 
 <p>Currently, bleeding-edge Rack is available
 via Git:</p>
@@ -227,13 +229,13 @@ via Git:</p>
 <pre><code>git clone git://github.com/rack/rack.git
 </code></pre>
 
-<p>The respository is <a href="http://github.com/rack/rack/tree/master">browsable
+<p>The repository is <a href="https://github.com/rack/rack">browsable
 online</a>,
 too.</p>
 
 <h2>Contact</h2>
 
-<p>Send patches, questions or bugs
+<p>Send questions or suggestions
 to <a href="mailto:rack-devel@googlegroups.com">rack-devel@googlegroups.com</a>
 (<a href="http://groups.google.com/group/rack-devel">archives</a>), or
 visit the Rack IRC channel <code>#rack</code>


### PR DESCRIPTION
Update with 1.3.0 release, fix broken links/redirects, remove gem mirror, don't ask for patches/bug reports on the mailing list.
