### PR TITLE
Fix Rack wiki link

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,7 @@
 
                 <ul>
                     <li><a href="http://chneukirchen.org/blog/archive/2007/02/introducing-rack.html">Introducing Rack</a>, an introductory blog post by Leah Neukirchen.</li>
-                    <li><a href="http://wiki.github.com/rack/rack">The Rack Wiki</a> has tutorials and presentations.</li>
+                    <li><a href="https://github.com/rack/rack/wiki">The Rack Wiki</a> has tutorials and presentations.</li>
                 </ul>
             </section>
 


### PR DESCRIPTION
Fixes link to Rack wiki found one http://rack.github.io/.